### PR TITLE
「友だち検索」で既に友だちになっているユーザーが表示されるバグを修正

### DIFF
--- a/files/sns/app/controllers/friends_controller.rb
+++ b/files/sns/app/controllers/friends_controller.rb
@@ -19,7 +19,7 @@ class FriendsController < ApplicationController
 
   def search
     ignore_ids = [@current_user.id] + @current_user.friend_ids
-    friends = User.where("name LIKE '%#{params[:name]}%' AND id NOT IN (#{ignore_ids.join(', ')})").order('name ASC')
+    friends = User.where("name LIKE ?", "%#{ActiveRecord::Base.sanitize_sql_like(params[:name])}%").where.not(id: ignore_ids).order('name ASC')
     render json: {friends: friends} and return
   end
 end


### PR DESCRIPTION
fixes #2

UIでテスト済み。
![Screen Shot 2022-06-24 at 17 24 25](https://user-images.githubusercontent.com/8053342/175495417-d6b8ccc2-5c21-44b6-80e3-70a64546b7bf.png)

